### PR TITLE
Write at once

### DIFF
--- a/java/src/gov/usgs/consumerclient/ConsumerClient.java
+++ b/java/src/gov/usgs/consumerclient/ConsumerClient.java
@@ -402,11 +402,10 @@ public class ConsumerClient {
 			String outFileName = outputDirectory + "/" + timeNow.toString()
 					+ fileName + "." + fileExtension;
 
-			// create an UTF-8 formatted printwriter to write to disk
-			PrintWriter fileWriter = new PrintWriter(outFileName, "UTF-8");
+			// Create string to write to file
+			String fileString = "";
 
 			for (int i = 0; i < numToWrite; i++) {
-
 				// don't try to write if we're out of messages
 				if (fileQueue.isEmpty()) {
 					continue;
@@ -415,18 +414,28 @@ public class ConsumerClient {
 				// get the next message to write
 				String messageString = fileQueue.remove();
 
-				// check to see if we were newline terminated, add a newline
-				// if we were not
+				// check to see if the message was newline terminated, add a newline
+				// if it isn't
 				if (messageString.charAt(messageString.length() - 1) != '\n') {
 					messageString = messageString.concat("\n");
 				}
 
-				// just call print
-				fileWriter.print(messageString);
+				// add the message to the file string
+				fileString += messageString;
 			}
 
-			// done with file
-			fileWriter.close();
+			// make sure we have something in the filestring to write.
+			if (!fileString.isEmpty()) {
+				// create an UTF-8 formatted printwriter to write to disk
+				PrintWriter fileWriter = new PrintWriter(outFileName, "UTF-8");
+
+				// just call print to write the whole set of messages (filestring) 
+				// in one go
+				fileWriter.print(fileString);
+
+				// done with file
+				fileWriter.close();
+			}
 
 			// Remember the time we wrote this file in seconds
 			lastFileWriteTime = timeNow / 1000;

--- a/java/src/gov/usgs/consumerclient/ConsumerClient.java
+++ b/java/src/gov/usgs/consumerclient/ConsumerClient.java
@@ -424,8 +424,9 @@ public class ConsumerClient {
 				fileString += messageString;
 			}
 
-			// make sure we have something in the filestring to write.
-			if (!fileString.isEmpty()) {
+			// make sure we have something in the filestring to write (besides 
+			// whitespace).
+			if (!fileString.trim().isEmpty()) {
 				// create an UTF-8 formatted printwriter to write to disk
 				PrintWriter fileWriter = new PrintWriter(outFileName, "UTF-8");
 

--- a/java/src/gov/usgs/hazdevbroker/ClientBase.java
+++ b/java/src/gov/usgs/hazdevbroker/ClientBase.java
@@ -27,7 +27,7 @@ public class ClientBase {
 	 */
 	public static final Integer VERSION_MAJOR = 0;
 	public static final Integer VERSION_MINOR = 2;
-	public static final Integer VERSION_PATCH = 2; 
+	public static final Integer VERSION_PATCH = 3; 
 
 	/**
 	 * Client Configuration ID

--- a/java/src/gov/usgs/launcher/Launcher.java
+++ b/java/src/gov/usgs/launcher/Launcher.java
@@ -48,6 +48,12 @@ public class Launcher {
 		} else if (option.equals("ArchiveClient")) {
 			new ArchiveClient();
 			ArchiveClient.main(args2);
+		} else if (option.equals("version")) {
+			System.out.println("v" + ClientBase.VERSION_MAJOR + "." + 
+				ClientBase.VERSION_MINOR + "." + 
+				ClientBase.VERSION_PATCH);
+	System.exit(1);
+		} 
 		} else {
 			System.out.println(
 					"Launcher: Invalid hazdev-broker <clientType> provided, only ConsumerClient, ProducerClient, or ArchiveClient supported.");

--- a/java/src/gov/usgs/launcher/Launcher.java
+++ b/java/src/gov/usgs/launcher/Launcher.java
@@ -52,8 +52,7 @@ public class Launcher {
 			System.out.println("v" + ClientBase.VERSION_MAJOR + "." + 
 				ClientBase.VERSION_MINOR + "." + 
 				ClientBase.VERSION_PATCH);
-	System.exit(1);
-		} 
+			System.exit(1);
 		} else {
 			System.out.println(
 					"Launcher: Invalid hazdev-broker <clientType> provided, only ConsumerClient, ProducerClient, or ArchiveClient supported.");


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines

* **What kind of change does this PR introduce?** 
This PR modifies the consumer client to attempt to write the entire message file in one operation, or as close to it as java will allow.

* **What is the current behavior?** 
The consumer client would write it's pending messages to file one at a time as separate string print operations as it iterated through the pending message queue.

* **What is the new behavior?**
The consumer client will now generate a string containing all the messages to write from the pending message queue and write this to the file as a single print operation. Also added code to prevent writing empty files.

* **Does this PR introduce a breaking change?** 
No

* **Other information**:
Java does not support atomic file writing, and the workarounds I found seemed to only work on POSIX systems.